### PR TITLE
Added an option to ignore diacritics.

### DIFF
--- a/Sample/Levenshtein/ViewController.swift
+++ b/Sample/Levenshtein/ViewController.swift
@@ -128,7 +128,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         var closeWords: [String] = []
         for word in words
         {
-            let distance = string.levenshtein(word, caseSensitive: false, diacriticSensitive: true)
+            let distance = string.levenshtein(word, caseSensitive: false, diacriticSensitive: false)
             if distance <= treshold
             {
                 closeWords.append(word)

--- a/Sample/Levenshtein/ViewController.swift
+++ b/Sample/Levenshtein/ViewController.swift
@@ -128,7 +128,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         var closeWords: [String] = []
         for word in words
         {
-            let distance = string.levenshtein(word, caseSensitive: false)
+            let distance = string.levenshtein(word, caseSensitive: false, diacriticSensitive: true)
             if distance <= treshold
             {
                 closeWords.append(word)

--- a/String+Levenshtein.swift
+++ b/String+Levenshtein.swift
@@ -44,7 +44,7 @@ extension String
     
     - returns: An Int representing levenshtein distance, the higher this number is, the more words are distant
     */
-    func levenshtein(anotherString: String, caseSensitive: Bool = true) -> Int
+    func levenshtein(anotherString: String, caseSensitive: Bool = true, diacriticSensitive: Bool = true) -> Int
     {
         // Early exits for empty strings
         if self.characters.count == 0 {
@@ -55,8 +55,20 @@ extension String
         }
         
         // Create arrays from strings
-        let a = Array(caseSensitive ? self.utf16 : self.lowercaseString.utf16)
-        let b = Array(caseSensitive ? anotherString.utf16 : anotherString.lowercaseString.utf16)
+        var firstString = self
+        var secondString = anotherString
+        if !caseSensitive
+        {
+            firstString = firstString.lowercaseString
+            secondString = secondString.lowercaseString
+        }
+        if !diacriticSensitive
+        {
+            firstString = firstString.stringByFoldingWithOptions(.DiacriticInsensitiveSearch, locale: NSLocale.currentLocale())
+            secondString = secondString.stringByFoldingWithOptions(.DiacriticInsensitiveSearch, locale: NSLocale.currentLocale())
+        }
+        let a = Array(firstString.utf16)
+        let b = Array(secondString.utf16)
         
         // Initialize a 2D array for scores
         let scores = Array2D(rows: a.count + 1, columns: b.count + 1)


### PR DESCRIPTION
The title pretty much says it all. Besides the caseSensitive parameter I added a diacriticSensitive parameter: setting it to false causes the function to ignore diacritics – "é" is considered the same as "e" and so on.
