### PR TITLE
Added a new operator (~=) to compare strings.

### DIFF
--- a/Sample/Levenshtein/ViewController.swift
+++ b/Sample/Levenshtein/ViewController.swift
@@ -128,11 +128,18 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         var closeWords: [String] = []
         for word in words
         {
+            // To use operator overloading switch the following code for the one commented out.
             let distance = string.levenshtein(word, caseSensitive: false, diacriticSensitive: false)
             if distance <= treshold
             {
                 closeWords.append(word)
             }
+            /*
+            if string ~= word
+            {
+                closeWords.append(word)
+            }
+            */
         }
         
         return closeWords

--- a/String+Levenshtein.swift
+++ b/String+Levenshtein.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 
+func ~= (left: String, right: String) -> Bool
+{
+    let tolerance = 40.0 // Set this to how different (in %) the strings can be while still returning true.
+    let averageCharacters = Double(left.characters.count + right.characters.count) / 2.0
+    let threshold = Int(averageCharacters * tolerance / 100)
+    return left.levenshtein(right, caseSensitive: false, diacriticSensitive: false) <= threshold
+}
+
 extension String
 {
     /**
@@ -39,8 +47,9 @@ extension String
     /**
     Compute levenshtein distance between self and given String objects
     
-    - parameter anotherString: A String object to compute the distance with
-    - parameter caseSensitive: Weither or not the comparison should be case sensiste
+     - parameter anotherString: A String object to compute the distance with
+     - parameter caseSensitive: Weither or not the comparison should be case sensitive
+     - parameter diacriticSensitive: Whether or not the comparison should be diacritic sensitive
     
     - returns: An Int representing levenshtein distance, the higher this number is, the more words are distant
     */


### PR DESCRIPTION
Now you should be able to do this:
"Louis-Ferdinand Céline" ~= "louis ferdinand celine" // true

By default it returns true if the strings are 40% different or less.
This value can be adjusted by changing the tolerance variable in the
operator definition.

I also added an example to the sample app, but I commented it out so as
to not interfere with the regular example.
